### PR TITLE
Add instructions for checking and installing WinGet on Windows 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,36 +30,34 @@ Please pay close attention to whether a step applies to Windows or Linux. To kee
 
 ### Repo Structure
 
+<!-- TODO: Re-make dir -->
+
 This is the directory structure sorting the files of this repo:
 
 ```text
-│   README.md
-│
-├───git
-│       git_config_ubuntu.md
-│       git_install_config_windows.md
-│
-├───powershell
-│       powershell_configure_windows.md
-│       powershell_install_windows.md
-│
-├───prompt_customization
-│       oh_my_posh_install_ubuntu.md
-│       oh_my_posh_install_windows.md
-│       posh_git_install_windows.md
-│
-├───tools_ubuntu
-│       collection_of_tools.md
-│       uv_install_ubuntu.md
-│
-├───tools_windows
-│       docker_desktop_windows.md
-│       vs_code_install_windows.md
-│       wsl_install_windows.md
-│
-└───windows_terminal
-        color_scheme_windows_terminal.json
-        windows_terminal_install_and_config.md
+├── LICENSE
+├── README.md
+├── git
+│   ├── git_config_ubuntu.md
+│   └── git_install_config_windows.md
+├── powershell
+│   ├── powershell_configure_windows.md
+│   └── powershell_install_windows.md
+├── prompt_customization
+│   ├── oh_my_posh_install_ubuntu.md
+│   ├── oh_my_posh_install_windows.md
+│   └── posh_git_install_windows.md
+├── tools_ubuntu
+│   ├── collection_of_tools.md
+│   └── uv_install_ubuntu.md
+├── tools_windows
+│   ├── docker_desktop_windows.md
+│   ├── vs_code_install_windows.md
+│   ├── winget_check_install_windows.md
+│   └── wsl_install_windows.md
+└── windows_terminal
+    ├── color_scheme_windows_terminal.json
+    └── windows_terminal_install_and_config.md
 ```
 
 In principle, all files are accessible from the list below and from each file there's a link back to the list.
@@ -68,27 +66,28 @@ In principle, all files are accessible from the list below and from each file th
 
 ### Windows 11:
 
-1. <a href="./powershell/powershell_install_windows.md">Install Powershell (cross-platform)</a>
-2. <a href="./git/git_install_config_windows.md">Install and configure Git</a>
-3. <a href="./prompt_customization/oh_my_posh_install_windows.md">Install Oh My Posh</a>
-4. <a href="./prompt_customization/posh_git_install_windows.md">Install posh-git</a>
-5. <a href="./powershell/powershell_configure_windows.md">Configure PowerShell and Windows PowerShell</a>
-6. <a href="./windows_terminal/windows_terminal_install_and_config.md">Install and configure Windows Terminal</a>
-7. <a href="./tools_windows/wsl_install_windows.md">Install WSL Ubuntu</a>
+1. <a href="./tools_windows/winget_check_install_windows.md">Check/Install winget</a>
+2. <a href="./powershell/powershell_install_windows.md">Install Powershell (cross-platform)</a>
+3. <a href="./git/git_install_config_windows.md">Install and configure Git</a>
+4. <a href="./prompt_customization/oh_my_posh_install_windows.md">Install Oh My Posh</a>
+5. <a href="./prompt_customization/posh_git_install_windows.md">Install posh-git</a>
+6. <a href="./powershell/powershell_configure_windows.md">Configure PowerShell and Windows PowerShell</a>
+7. <a href="./windows_terminal/windows_terminal_install_and_config.md">Install and configure Windows Terminal</a>
+8. <a href="./tools_windows/wsl_install_windows.md">Install WSL Ubuntu</a>
 
 ### Ubuntu on WSL2:
-8. <a href="./prompt_customization/oh_my_posh_install_ubuntu.md">Install Oh My Posh</a>
-9. <a href="./git/git_config_ubuntu.md">Configure Git</a>
-10. <a href="./tools_ubuntu/uv_install_ubuntu.md">Install uv</a>
+9. <a href="./prompt_customization/oh_my_posh_install_ubuntu.md">Install Oh My Posh</a>
+10. <a href="./git/git_config_ubuntu.md">Configure Git</a>
+11. <a href="./tools_ubuntu/uv_install_ubuntu.md">Install uv</a>
 
 ### Optional on Ubuntu on WSL2
 
-- <a href="./tools_ubuntu/collection_of_tools.md">Optional Tools: sqlite3, cmatrix, neofetch, cowsay, fortune, etc.</a>
+12. <a href="./tools_ubuntu/collection_of_tools.md">Optional Tools: sqlite3, cmatrix, neofetch, cowsay, fortune, etc.</a>
 
 ### Windows 11:
 
-11. <a href="./tools_windows/docker_desktop_windows.md">Install Docker Desktop</a>
-12. <a href="./tools_windows/vs_code_install_windows.md">Install VS Code and extensions</a>
+13. <a href="./tools_windows/docker_desktop_windows.md">Install Docker Desktop</a>
+14. <a href="./tools_windows/vs_code_install_windows.md">Install VS Code and extensions</a>
 
 ### Optional on Windows 11
 

--- a/tools_windows/winget_check_install_windows.md
+++ b/tools_windows/winget_check_install_windows.md
@@ -1,0 +1,33 @@
+<a href="../README.md">Back to README</a>
+
+# WinGet
+
+## General Considerations
+
+[WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/) is a command line tool enabling users to discover, install, upgrade, remove and configure applications on Windows 10, Windows 11, and Windows Server 2025 computers. This tool is the client interface to the Windows Package Manager service.
+
+## Why WinGet
+
+I use winget because it comes with Windows 11 and I find it convenient because I don't have to leave the terminal. From within the terminal I can install, update, and remove whatever program I want.
+
+## Check if WinGet is Available
+
+On Windows 11, the Windows Package Manager (winget) is included by default starting with version 21H2 (build 22000) and later. winget might not be available if:
+
+1. You're using a corporate or enterprise-managed device with restrictions.
+2. You're on a custom Windows image where optional features were removed.
+3. The App Installer is missing or outdated.
+
+To check if winget is available we can do a version check. Open a Windows PowerShell terminal by typing in the search bar "Windows Powershell" and press Windows PowerShell. Run the following command in Windows PowerShell to check if winget is installed (run means here: type and hit enter):
+
+```powershell
+winget --version
+```
+
+If you get a version number you have winget. If you get something like `winget : The term 'winget' is not recognized as...` then you probably don't have winget.
+
+## Install WinGet
+
+The easiest way to install WinGet is to install App Installer from the Microsoft Store. If installation via Microsoft Store fails, ensure your system is updated and that the Microsoft Store is functioning properly.
+
+<a href="../README.md">Back to README</a>


### PR DESCRIPTION
Summary

This pull request adds a new markdown file with instructions for checking and installing WinGet (Windows Package Manager) on Windows 11. It includes:

- A brief explanation of what WinGet is and why it's useful.
- Steps to verify if WinGet is available on the system.
- Guidance on how to install WinGet via the Microsoft Store.
- A troubleshooting tip for installation issues.

Motivation

Since many tools in the development setup rely on WinGet , it's important to ensure users have it installed and know how to verify its availability. This addition improves the clarity and completeness of the setup documentation.