### PR TITLE
docs: Python REPL + Oh My Posh terminal note and jsonc settings refs

### DIFF
--- a/additional-info/machine-settings.jsonc
+++ b/additional-info/machine-settings.jsonc
@@ -1,5 +1,3 @@
-# VS Code Settings Machine (Remote)
-```json
 {
     // Editor
     "ruff.importStrategy": "useBundled",
@@ -23,6 +21,5 @@
     "autoDocstring.docstringFormat": "google-notypes",
     // Jupyter
     "jupyter.interactiveWindow.textEditor.executeSelection": true,
-    "jupyter.interactiveWindow.creationMode": "perFile",
+    "jupyter.interactiveWindow.creationMode": "perFile"
 }
-```

--- a/additional-info/user-settings.jsonc
+++ b/additional-info/user-settings.jsonc
@@ -1,6 +1,3 @@
-# VS Code Settings User (Local)
-
-```json
 {
     // General
     "security.workspace.trust.untrustedFiles": "newWindow",
@@ -25,6 +22,7 @@
     "terminal.integrated.cursorStyle": "line",
     "terminal.integrated.fontFamily": "Hack Nerd Font",
     "terminal.integrated.fontSize": 16,
+    "terminal.integrated.shellIntegration.enabled": false,
     "terminal.integrated.suggest.enabled": false,
     "terminal.integrated.tabs.enabled": false,
     "workbench.secondarySideBar.defaultVisibility": "hidden",
@@ -42,6 +40,5 @@
     "chat.mcp.gallery.enabled": true,
     "chat.viewSessions.enabled": false,
     "claudeCode.preferredLocation": "panel",
-    "autoDocstring.docstringFormat": "google-notypes",
+    "autoDocstring.docstringFormat": "google-notypes"
 }
-```

--- a/tools-windows/vs-code-install-windows.md
+++ b/tools-windows/vs-code-install-windows.md
@@ -163,8 +163,8 @@ However, Ruff does not replace the Python extension or Pylance for:
 
 The (Python) setup in this environment is maintained in dedicated configuration files, instead of an inline sample `settings.json` in this document.
 
-- Local VS Code user settings (Windows side): <a href="../additional-info/user-settings.md">user-settings.md</a>
-- Remote VS Code machine settings (WSL side): <a href="../additional-info/machine-settings.md">machine-settings.md</a>
+- Local VS Code user settings (Windows side): <a href="../additional-info/user-settings.jsonc">user-settings.jsonc</a>
+- Remote VS Code machine settings (WSL side): <a href="../additional-info/machine-settings.jsonc">machine-settings.jsonc</a>
 - Ruff configuration: <a href="../additional-info/ruff.toml">ruff.toml</a>
 
 This reflects the current setup best:
@@ -174,6 +174,22 @@ This reflects the current setup best:
 - Python formatting, linting, and code actions are aligned with the Ruff + Pylance workflow described above.
 
 If you adopt this setup, update any placeholder paths in the referenced files (for example, the Ruff config path in remote settings) to match your system.
+
+### Python REPL + Oh My Posh in VS Code Terminal
+
+When using Oh My Posh with a multi-line prompt (for example `atomic`) in VS Code's integrated terminal, pressing `Ctrl+L` in Python REPL sessions can cause redraw issues where the Python prompt (`>>>`) appears behind prompt lines.
+
+In this setup, the following local setting is intentional and used as a practical workaround:
+
+```json
+"terminal.integrated.shellIntegration.enabled": false
+```
+
+Disabling shell integration makes the VS Code terminal behave more like a standard terminal emulator for this specific workflow. In my setup, Windows Terminal does not show this redraw issue under the same conditions.
+
+Shell integration can still be useful in other workflows, so treat this as a setup-specific choice rather than a universal recommendation.
+
+Source/discussion: [Suddenly REPL in vscode becomes weird](https://discourse.julialang.org/t/suddenly-repl-in-vscode-becomes-weird/85459/4)
 
 Note: Behavior in VS Code's integrated terminal (prompt rendering, clear-screen behavior, shell integration features) can vary by shell, prompt theme, and extension combination. Keep terminal-related settings in local user settings and adjust them only if you encounter issues in your own setup.
 


### PR DESCRIPTION
## Summary
- document VS Code terminal redraw issue with Python REPL + Oh My Posh
- explain why `terminal.integrated.shellIntegration.enabled` is set to `false` in this setup
- replace settings reference files with `.jsonc` variants and update links

## Notes
- setup-specific workaround (not universal)
- source link included in docs