### PR TITLE
chore: shorten github.com alias

### DIFF
--- a/git/git-config-ubuntu.md
+++ b/git/git-config-ubuntu.md
@@ -137,23 +137,23 @@ Using the SSH keys saved in Windows (OneDrive) inside WSL Ubuntu:
     Add the following to `~/.ssh/config`:
 
     ```text
-    Host github-ssh-connection
+    Host github
         HostName github.com
         IdentityFile /mnt/c/Users/<username>/OneDrive/Documents/ssh-keys/github
     ```
 
-    Again, make sure to use the correct path to where your identity file lives. Here, `github-ssh-connection` is a custom alias. You can name it anything, but be consistent when using it in git clone commands.
+    Again, make sure to use the correct path to where your identity file lives. Here, `github` is a custom alias. You can name it anything, but be consistent when using it in git clone commands.
 
 5. Test the SSH connection (GitHub identity) to GitHub:
 
     ```bash
-    ssh -T git@github-ssh-connection
+    ssh -T git@github
     ```
 
 6. Now we can use:
 
     ```bash
-    git clone git@github-ssh-connection:<username>/repo.git
+    git clone git@github:<username>/repo.git
     ```
 
 7. To get an overview of the Git configuration use:

--- a/git/git-install-config-windows.md
+++ b/git/git-install-config-windows.md
@@ -146,7 +146,7 @@ Verify it with the command given above.
 5. Add the following to `"$HOME\.ssh\config"`:
    
 	```text
-	Host github-ssh-connection
+	Host github
 	   HostName github.com
 	   IdentityFile "~/OneDrive/Documents/ssh-keys/github"
 	```
@@ -156,7 +156,7 @@ Verify it with the command given above.
 6. Test the SSH connection to GitHub:
 
     ```shell
-    ssh -T git@github-ssh-connection
+    ssh -T git@github
     ```
 
 7. Normally to clone a repo using SSH we do something like:
@@ -165,10 +165,9 @@ Verify it with the command given above.
     git clone git@github.com:<username>/repo.git
     ```
 
-    Since `"$HOME\.ssh\config"` contains an alias for the host name with the location of the identity file to associate it with the host, we can substitute @github.com: with @github-ssh-connection:
-
+    Since `"$HOME\.ssh\config"` contains an alias for the host name with the location of the identity file to associate it with the host, we can substitute @github.com: with @github:
     ```powershell
-    git clone git@github-ssh-connection:<username>/repo.git
+    git clone git@github:<username>/repo.git
     ```
 
 <a href="../README.md">Back to README</a>


### PR DESCRIPTION
Changes github.com alias from github-ssh-connection to github for both Windows and WSL Ubuntu.