### PR TITLE
docs: restructure setup docs and harden WSL2 Bash profile guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [3.0.0] - 2026-07-10
+
+### Changed
+
+- BREAKING: Split the Windows Terminal guide into separate check-install and configuration documents.
+- Updated README.md to the new 3.0.0 release version and current navigation flow.
+- Revised the following documentation files as part of the major refresh:
+
+    - additional-info/user-settings.jsonc
+    - git/git-install-config-windows.md
+    - powershell/powershell-configure-windows.md
+    - powershell/powershell-install-windows.md
+    - prompt-customization/oh-my-posh-install-windows.md
+    - tools-ubuntu/uv-install-ubuntu.md
+    - tools-windows/winget-check-install-windows.md
+    - tools-windows/wsl-install-windows.md
+
+- Replaced windows-terminal/windows-terminal-install-and-config.md with:
+
+    - windows-terminal/windows-terminal-check-install.md
+    - windows-terminal/windows-terminal-config.md
+
 ## [2.0.0] - 2026-02-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [3.1.0] - 2026-07-11
+
+### Changed
+
+- Updated Ubuntu setup docs to align with WSL2 login shell behavior:
+
+    - prompt-customization/oh-my-posh-install-ubuntu.md
+    - tools-ubuntu/uv-install-ubuntu.md
+
+- Replaced `.profile` export append instructions with anchor-based, idempotent insertion before the `# if running bash` block to preserve required startup ordering.
+- Kept `.bashrc` interactive setup snippets as append operations, now with idempotency guards for Oh My Posh and uv/uvx completions.
+- Added a new reference document:
+
+    - additional-info/profile-vs-bashrc-wsl2.md
+
+- Updated README navigation to insert the new WSL2 intro section before Ubuntu steps for Oh My Posh, Git, and uv.
+- Bumped project version from 3.0.0 to 3.1.0 in README and changelog.
+
 ## [3.0.0] - 2026-07-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Version](https://img.shields.io/badge/version-3.0.0-brightgreen)
+![Version](https://img.shields.io/badge/version-3.1.0-brightgreen)
 ![GitHub last commit](https://img.shields.io/github/last-commit/karelplanken/kde?color=blue)
 ![GitHub repo size](https://img.shields.io/github/repo-size/karelplanken/kde?color=orange)
 ![GitHub issues](https://img.shields.io/github/issues/karelplanken/kde?color=yellow)
@@ -46,6 +46,7 @@ This is the directory structure sorting the files of this repo:
 ├── README.md
 ├── additional-info
 │   ├── interactive-matplotlib-plots-ubuntu-wsl.md
+│   ├── profile-vs-bashrc-wsl2.md
 │   ├── machine-settings.jsonc
 │   ├── ruff.toml
 │   ├── user-settings.jsonc
@@ -91,18 +92,19 @@ In principle, all files are accessible from the list below and from each file th
 9. <a href="./tools-windows/wsl-install-windows.md">Install WSL Ubuntu</a>
 
 ### Ubuntu on WSL 2:
-10. <a href="./prompt-customization/oh-my-posh-install-ubuntu.md">Install Oh My Posh</a>
-11. <a href="./git/git-config-ubuntu.md">Configure Git</a>
-12. <a href="./tools-ubuntu/uv-install-ubuntu.md">Install uv</a>
+10. <a href="./additional-info/profile-vs-bashrc-wsl2.md">.profile vs .bashrc on WSL2</a>
+11. <a href="./prompt-customization/oh-my-posh-install-ubuntu.md">Install Oh My Posh</a>
+12. <a href="./git/git-config-ubuntu.md">Configure Git</a>
+13. <a href="./tools-ubuntu/uv-install-ubuntu.md">Install uv</a>
 
 ### Optional on Ubuntu on WSL 2
 
-13. <a href="./tools-ubuntu/collection-of-tools.md">Optional Tools: SQLite3, Cmatrix, Fastfetch, Cowsay, Fortune, etc.</a>
+14. <a href="./tools-ubuntu/collection-of-tools.md">Optional Tools: SQLite3, Cmatrix, Fastfetch, Cowsay, Fortune, etc.</a>
 
 ### Windows 11:
 
-14. <a href="./tools-windows/docker-desktop-install-windows.md">Install Docker Desktop</a>
-15. <a href="./tools-windows/vs-code-install-windows.md">Install VS Code and extensions</a>
+15. <a href="./tools-windows/docker-desktop-install-windows.md">Install Docker Desktop</a>
+16. <a href="./tools-windows/vs-code-install-windows.md">Install VS Code and extensions</a>
 
 ### Optional on Windows 11
 
@@ -123,6 +125,7 @@ In the files below you'll find some additional info on certain topics and potent
 
 - <a href="./additional-info/interactive-matplotlib-plots-ubuntu-wsl.md">Viewing Matplotlib Plots Interactively WSL 2 Ubuntu</a>
 - <a href="./additional-info/wsl2-shell-initialization.md">WSL 2 Ubuntu Shell Initialization</a>
+- <a href="./additional-info/profile-vs-bashrc-wsl2.md">.profile vs .bashrc on WSL2</a>
 
 ## Project Info
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Version](https://img.shields.io/badge/version-2.1.0-brightgreen)
+![Version](https://img.shields.io/badge/version-3.0.0-brightgreen)
 ![GitHub last commit](https://img.shields.io/github/last-commit/karelplanken/kde?color=blue)
 ![GitHub repo size](https://img.shields.io/github/repo-size/karelplanken/kde?color=orange)
 ![GitHub issues](https://img.shields.io/github/issues/karelplanken/kde?color=yellow)
@@ -10,9 +10,9 @@
 
 ## Introduction
 
-This document outlines the complete setup of my development environment on a Windows 11 machine (x64) using KDE and WSL 2. It serves as a step-by-step guide for installing and configuring the tools I use regularly.
+This document outlines the complete setup of my development environment on a laptop running Windows 11 Enterprise (x64) with WSL 2. It serves as a step-by-step guide for installing and configuring the tools I use regularly.
 
-My workflow spans multiple languages, primarily Python, JavaScript, and C/C++—with the latter two focused on embedded development for platforms like Arduino and Raspberry Pi. In addition to the programming languages I also use my setup to write in markdown, HTML, and CSS.
+My primary language is Python, which I use mainly for application development on Linux. My workflow also spans JavaScript, C, and C++. Python (via MicroPython/CircuitPython) and C++ are used for embedded development on platforms like Arduino and RPi Pico, while full Python runs on RPi for general-purpose projects. In addition to these programming languages, I also use my setup to write in Markdown, HTML, and CSS.
 
 The system runs Windows 11 with Windows Subsystem for Linux 2 (WSL 2), using the default Ubuntu distribution (though I still think it should've been called Linux Subsystem for Windows, but I digress...).
 
@@ -45,29 +45,33 @@ This is the directory structure sorting the files of this repo:
 ├── LICENSE
 ├── README.md
 ├── additional-info
-│   ├── interactive-matplotlib-plots-ubuntu-wsl.md
-│   └── wsl2-shell-initialization.md
+│   ├── interactive-matplotlib-plots-ubuntu-wsl.md
+│   ├── machine-settings.jsonc
+│   ├── ruff.toml
+│   ├── user-settings.jsonc
+│   └── wsl2-shell-initialization.md
 ├── git
-│   ├── git-config-ubuntu.md
-│   └── git-install-config-windows.md
+│   ├── git-config-ubuntu.md
+│   └── git-install-config-windows.md
 ├── powershell
-│   ├── powershell-configure-windows.md
-│   └── powershell-install-windows.md
+│   ├── powershell-configure-windows.md
+│   └── powershell-install-windows.md
 ├── prompt-customization
-│   ├── oh-my-posh-install-ubuntu.md
-│   ├── oh-my-posh-install-windows.md
-│   └── posh-git-install-windows.md
+│   ├── oh-my-posh-install-ubuntu.md
+│   ├── oh-my-posh-install-windows.md
+│   └── posh-git-install-windows.md
 ├── tools-ubuntu
-│   ├── collection-of-tools.md
-│   └── uv-install-ubuntu.md
+│   ├── collection-of-tools.md
+│   └── uv-install-ubuntu.md
 ├── tools-windows
-│   ├── docker-desktop-install-windows.md
-│   ├── vs-code-install-windows.md
-│   ├── winget-check-install-windows.md
-│   └── wsl-install-windows.md
+│   ├── docker-desktop-install-windows.md
+│   ├── vs-code-install-windows.md
+│   ├── winget-check-install-windows.md
+│   └── wsl-install-windows.md
 └── windows-terminal
     ├── color-scheme-windows-terminal.json
-    └── windows-terminal-install-and-config.md
+    ├── windows-terminal-check-install.md
+    └── windows-terminal-config.md
 ```
 
 In principle, all files are accessible from the list below and from each file there's a link back to the list.
@@ -77,27 +81,28 @@ In principle, all files are accessible from the list below and from each file th
 ### Windows 11:
 
 1. <a href="./tools-windows/winget-check-install-windows.md">Check/Install WinGet</a>
-2. <a href="./powershell/powershell-install-windows.md">Install PowerShell (cross-platform)</a>
-3. <a href="./git/git-install-config-windows.md">Install and configure Git</a>
-4. <a href="./prompt-customization/oh-my-posh-install-windows.md">Install Oh My Posh</a>
-5. <a href="./prompt-customization/posh-git-install-windows.md">Install posh-git</a>
-6. <a href="./powershell/powershell-configure-windows.md">Configure PowerShell and Windows PowerShell</a>
-7. <a href="./windows-terminal/windows-terminal-install-and-config.md">Install and configure Windows Terminal</a>
-8. <a href="./tools-windows/wsl-install-windows.md">Install WSL Ubuntu</a>
+2. <a href="./windows-terminal/windows-terminal-check-install.md">Check Windows Terminal install</a>
+3. <a href="./powershell/powershell-install-windows.md">Install PowerShell (cross-platform)</a>
+4. <a href="./git/git-install-config-windows.md">Install and configure Git</a>
+5. <a href="./prompt-customization/oh-my-posh-install-windows.md">Install Oh My Posh</a>
+6. <a href="./prompt-customization/posh-git-install-windows.md">Install posh-git</a>
+7. <a href="./powershell/powershell-configure-windows.md">Configure PowerShell and Windows PowerShell</a>
+8. <a href="./windows-terminal/windows-terminal-config.md">Configure Windows Terminal</a>
+9. <a href="./tools-windows/wsl-install-windows.md">Install WSL Ubuntu</a>
 
 ### Ubuntu on WSL 2:
-9. <a href="./prompt-customization/oh-my-posh-install-ubuntu.md">Install Oh My Posh</a>
-10. <a href="./git/git-config-ubuntu.md">Configure Git</a>
-11. <a href="./tools-ubuntu/uv-install-ubuntu.md">Install uv</a>
+10. <a href="./prompt-customization/oh-my-posh-install-ubuntu.md">Install Oh My Posh</a>
+11. <a href="./git/git-config-ubuntu.md">Configure Git</a>
+12. <a href="./tools-ubuntu/uv-install-ubuntu.md">Install uv</a>
 
 ### Optional on Ubuntu on WSL 2
 
-12. <a href="./tools-ubuntu/collection-of-tools.md">Optional Tools: SQLite3, Cmatrix, Fastfetch, Cowsay, Fortune, etc.</a>
+13. <a href="./tools-ubuntu/collection-of-tools.md">Optional Tools: SQLite3, Cmatrix, Fastfetch, Cowsay, Fortune, etc.</a>
 
 ### Windows 11:
 
-13. <a href="./tools-windows/docker-desktop-install-windows.md">Install Docker Desktop</a>
-14. <a href="./tools-windows/vs-code-install-windows.md">Install VS Code and extensions</a>
+14. <a href="./tools-windows/docker-desktop-install-windows.md">Install Docker Desktop</a>
+15. <a href="./tools-windows/vs-code-install-windows.md">Install VS Code and extensions</a>
 
 ### Optional on Windows 11
 

--- a/additional-info/profile-vs-bashrc-wsl2.md
+++ b/additional-info/profile-vs-bashrc-wsl2.md
@@ -1,0 +1,81 @@
+<a href="../README.md">Back to README</a>
+
+# .profile vs .bashrc on WSL2
+
+## Why WSL is different from a normal Linux terminal
+
+On most Linux desktop terminals, opening a new tab starts a non-login interactive shell, so `.bashrc` is read and `.profile` is usually not part of that startup path.
+
+On WSL2, Bash is commonly launched by `wsl.exe` as a login + interactive shell, so `.profile` runs and then sources `.bashrc` as part of the same startup sequence each time a new terminal window or tab is opened.
+
+## The convention, and the choice made here
+
+The standard split is:
+
+- Login-scope environment and PATH exports in `.profile`
+- Interactive-only setup in `.bashrc` (prompt, aliases, completions, interactive helpers)
+
+Two valid approaches exist:
+
+1. Keep most setup centralized in `.bashrc`
+2. Keep guarded PATH/env exports in `.profile`, keep interactive setup in `.bashrc`
+
+This repo uses option 2. It aligns with login-scope conventions and also protects against a bare non-login `bash` started from within an already-running shell.
+
+## Ordering is a hard requirement
+
+Because `.bashrc` is sourced from `.profile`, any tool initialized in `.bashrc` via `eval` (for example Oh My Posh and uv/uvx completions) must already be discoverable on `PATH`.
+
+That means the `.profile` block that sources `.bashrc` must stay last, after all PATH/env exports.
+
+## Canonical structure
+
+Use this exact order in `.profile`:
+
+1. umask comment (unchanged)
+2. Guarded PATH block for `$HOME/bin`
+3. Guarded PATH block for `$HOME/.local/bin`
+4. Plain env/PATH exports (`UV_NO_MODIFY_PATH`)
+5. LAST: the `if running bash ... source ~/.bashrc` block
+
+`.bashrc` keeps interactive-only setup: prompt initialization, uv/uvx completion evals, nvm loading, aliases.
+
+## Adding new exports safely
+
+For any future install step that needs to add PATH/env exports to `.profile`, use this anchor-based, idempotent insertion pattern. Do not use blind `>>` append for `.profile` exports in this repo.
+
+```bash
+PROFILE="$HOME/.profile"
+ANCHOR='^# if running bash$'
+MARKER='<unique string from this block, e.g. env var name>'
+
+if ! grep -q "$MARKER" "$PROFILE"; then
+    if grep -q "$ANCHOR" "$PROFILE"; then
+        sed -i "/$ANCHOR/i\\
+# <comment>\\
+export VAR=value\\
+" "$PROFILE"
+    else
+        echo "WARNING: anchor line not found in $PROFILE - appending to end instead, check ordering manually" >&2
+        printf '\n# <comment>\nexport VAR=value\n' >> "$PROFILE"
+    fi
+fi
+```
+
+Why this is required:
+
+- Blind append can break required ordering by placing exports after the `.bashrc` source block.
+- The anchor existence check prevents a silent no-op if the anchor line is missing or changed.
+
+## How to verify
+
+After any change, open a genuinely new WSL terminal (new login shell) and run:
+
+- `echo "$PATH" | tr ':' '\n' | sort | uniq -d` -> expected: no output (no duplicates)
+- `echo "$PATH" | tr ':' '\n' | grep -E "\.local/bin"` -> expected: present once
+- `complete -p uv uvx` -> expected: shows registered `_uv`/`_uvx` completion functions, no errors
+- `oh-my-posh --version` -> expected: prints a version, no shell-start error
+
+Do not rely only on `source ~/.profile` for this validation.
+
+<a href="../README.md">Back to README</a>

--- a/additional-info/profile-vs-bashrc-wsl2.md
+++ b/additional-info/profile-vs-bashrc-wsl2.md
@@ -40,6 +40,48 @@ Use this exact order in `.profile`:
 
 `.bashrc` keeps interactive-only setup: prompt initialization, uv/uvx completion evals, nvm loading, aliases.
 
+The default Ubuntu on WSL2 profile typically sources `.bashrc` from a single `# if running bash` block (with no extra outer guard). The example below follows the required order and can be used as a reference template:
+
+```bash
+# ~/.profile: executed by the command interpreter for login shells.
+# This file is not read by bash(1), if ~/.bash_profile or ~/.bash_login
+# exists.
+# see /usr/share/doc/bash/examples/startup-files for examples.
+# the files are located in the bash-doc package.
+
+# the default umask is set in /etc/profile; for setting the umask
+# for ssh logins, install and configure the libpam-umask package.
+#umask 022
+
+# set PATH so it includes user's private bin if it exists
+if [ -d "$HOME/bin" ] && [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
+    PATH="$HOME/bin:$PATH"
+fi
+
+# set PATH so it includes user's private bin if it exists
+if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    PATH="$HOME/.local/bin:$PATH"
+fi
+
+# if running bash
+if [ -n "$BASH_VERSION" ]; then
+    # include .bashrc if it exists
+    if [ -f "$HOME/.bashrc" ]; then
+        . "$HOME/.bashrc"
+    fi
+fi
+```
+
+To edit `.profile` manually with Nano:
+
+Open `.profile`:
+
+```bash
+sudo nano ~/.profile
+```
+
+Then edit the content following the instruction line shown at the bottom of the screen. After editing, close the file with `Ctrl`+`O`, `Enter`, and then `Ctrl`+`X`.
+
 ## Adding new exports safely
 
 For any future install step that needs to add PATH/env exports to `.profile`, use this anchor-based, idempotent insertion pattern. Do not use blind `>>` append for `.profile` exports in this repo.

--- a/additional-info/user-settings.jsonc
+++ b/additional-info/user-settings.jsonc
@@ -5,17 +5,20 @@
     "files.autoSave": "afterDelay",
     "files.dialog.defaultPath": "\\path\\to\\directory",
     // Workbench
-    "workbench.colorTheme": "Default Dark Modern",
+    "workbench.colorTheme": "Dark Modern",
     "workbench.editor.enablePreview": false,
     "workbench.editor.tabSizing": "shrink",
+    "workbench.editor.useModal": "off", // "off", "some", "all"
     "workbench.iconTheme": "material-icon-theme",
-    // "workbench.settings.editor": "json",
+    "workbench.settings.editor": "json",
     // Editor
     "editor.fontFamily": "Cascadia Code",
     "editor.fontSize": 16,
     "editor.formatOnPaste": true,
     "editor.formatOnSave": true,
     "editor.formatOnSaveMode": "file",
+    // Docstring format
+    "autoDocstring.docstringFormat": "google-notypes",
     // Debug
     "debug.toolBarLocation": "docked",
     // Terminal
@@ -32,13 +35,20 @@
     "github.copilot.enable": {
         "*": true,
         "plaintext": false,
+        "markdown": true,
         "scminput": false,
-        "yaml": false
+        "yaml": false,
+        "jsonc": true,
+        "python": true
     },
     "github.copilot.nextEditSuggestions.enabled": true,
     // AI chat
     "chat.mcp.gallery.enabled": true,
     "chat.viewSessions.enabled": false,
+    "chat.fontSize": 16,
+    "chat.editor.fontSize": 16,
     "claudeCode.preferredLocation": "panel",
-    "autoDocstring.docstringFormat": "google-notypes"
+    "security.allowedUNCHosts": [
+        "wsl.localhost"
+    ]
 }

--- a/git/git-install-config-windows.md
+++ b/git/git-install-config-windows.md
@@ -4,7 +4,7 @@
 
 ## General Notes and Considerations
 
-I prefer to work with Git using SSH Key-Pair for authentication, so you'll find how to set that up here. Since these instructions concern configuring Git on Windows I assume you're on Windows using PowerShell. Furthermore I assume that you also want to use the same SSH-key pairs from within WSL 2 as you do in Windows (this file is part of my development environment setup, which uses WSL 2). For this you'll save the SSH key pair in a OneDrive directory, which obviously is on the Windows side.
+I prefer to work with Git using SSH Key-Pair for authentication, so you'll find how to set that up here. Since these instructions concern configuring Git on Windows I assume you're on Windows using PowerShell. Furthermore I assume that you also want to use the same SSH-key pairs from within WSL 2 as you do in Windows. For this you'll save the SSH key pair in a OneDrive directory, which obviously is on the Windows side.
 
 Note: Git is a distributed version control system. It allows you to track changes in your code, collaborate with others, and manage different versions of your project, all on your local machine or across multiple systems.
 
@@ -21,8 +21,8 @@ You can use Git without GitHub, but you can't use GitHub effectively without Git
 
 When installing Git, particularly if you're not familiar with it, just accept all defaults except:
 
-- Add entry to Windows Terminal
-- Default text editor: choose nano or VS Code
+- Check: "Add a Git Bash Profile for Windows Terminal"
+- Default text editor: choose Notepad or VS Code
 
 Many settings can be changed later and the default values for the install avoid introducing complexity that could make it harder to wrap your mind around how git works. You can download the installer from the official [Git](https://git-scm.com/downloads) download site. Or from within a PowerShell terminal run:
 

--- a/powershell/powershell-configure-windows.md
+++ b/powershell/powershell-configure-windows.md
@@ -14,7 +14,9 @@ Both PowerShell and Windows PowerShell have a profile script file named `Microso
 
     ```powershell
     if (!(Test-Path -Path $PROFILE)) {
-        New-Item -ItemType File -Path $PROFILE -Force
+    New-Item -ItemType File -Path $PROFILE -Force
+    } else {
+        Write-Host "$(Split-Path $PROFILE -Leaf) already exists!"
     }
     ```
     

--- a/powershell/powershell-install-windows.md
+++ b/powershell/powershell-install-windows.md
@@ -24,13 +24,13 @@ Since Windows comes with Windows PowerShell, you can install [PowerShell](https:
     winget install -e --id Microsoft.PowerShell --source winget
     ```
 
-3. After restarting Windows Terminal, verify the install with:
+3. Verify the install with:
 
     ```powershell
     pwsh --version
     ```
 
-    or even better, just start PowerShell and run the same command in there.
+    If you don't get theexpected output, i.e. `PowerShell 7.6.3` or similar, restart Windows PowerShell or even better, just start PowerShell and run the same command in there.
 
 If the installation was successful, you can launch PowerShell from the Start menu. Once Windows Terminal is installed, which is probably already the case since Windows 11 comes with Windows Terminal, I plan to set PowerShell as the default profile. I'll come back to that later.
 
@@ -48,15 +48,11 @@ To set it:
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ```
 	
-Do the above for both PowerShell and Windows PowerShell because Windows PowerShell is still the default shell in some contexts. In my case, a freshly installed Windows 11 Enterprise edition had the execution policy set to RemoteSigned for LocalMachine. Since I want to follow the Principle of Least Privilege, I reset this to Undefined:
-
-```powershell
-Set-ExecutionPolicy -ExecutionPolicy Undefined -Scope LocalMachine
-```
+Do the above for both PowerShell and Windows PowerShell because Windows PowerShell is still the default shell in some contexts.
 
 Note: The RemoteSigned execution policy allows locally created scripts to run freely, while requiring scripts downloaded from the internet to be signed by a trusted publisher. This strikes a balance between security and convenience, making it ideal for development environments like this one.
 
-Setting the execution policy only for the current user aligns with the Principle of Least Privilege and the Security with Usability principle. It ensures that:
+Setting the execution policy for the current user aligns with the Principle of Least Privilege and the Security with Usability principle. It ensures that:
 
 - You don't affect other users or system-wide settings.
 - You maintain a secure and personalized configuration.

--- a/prompt-customization/oh-my-posh-install-ubuntu.md
+++ b/prompt-customization/oh-my-posh-install-ubuntu.md
@@ -42,32 +42,7 @@ Note: Except for AArch64/ARM64, Oh My Posh can be installed using Homebrew. Howe
 
     If you get True then all is well and you can proceed. If you get False then Oh My Posh, i.e. the executable oh-my-posh, ended up somewhere else. In the latter case you may want to search for its location and use that path in the next steps.
 
-3. Open `.profile`:
-
-    ```bash
-    sudo nano ~/.profile
-    ```
-
-    then comment out the following lines:
-    
-    ```bash
-    # set PATH so it includes user's private bin if it exists
-    if [ -d "$HOME/.local/bin" ] ; then
-        PATH="$HOME/.local/bin:$PATH"
-    fi
-    ```
-
-    to match:
-    ```bash
-    # set PATH so it includes user's private bin if it exists
-    #if [ -d "$HOME/.local/bin" ] ; then
-    #    PATH="$HOME/.local/bin:$PATH"
-    #fi
-    ```
-    
-    close the `.profile` file (`Ctrl`+`O`, `Enter`, and then `Ctrl`+`X`)
-
-4. For user installed applications that live in `$HOME/.local/bin` to be available, `$HOME/.local/bin` should be in the `$PATH` environment variable. Add this guarded block to `.profile` immediately before `# if running bash`:
+3. For user installed applications that live in `$HOME/.local/bin` to be available, `$HOME/.local/bin` should be in the `$PATH` environment variable. Add this guarded block to `.profile` immediately before `# if running bash`:
 
 	```bash
     PROFILE="$HOME/.profile"
@@ -89,7 +64,7 @@ Note: Except for AArch64/ARM64, Oh My Posh can be installed using Homebrew. Howe
     fi
 	```
 
-5. Initialize Oh My Posh with a theme. To use Oh My Posh with a theme of your choice (e.g., `atomic`), add the following idempotent initialization command to your `.bashrc` file:
+4. Initialize Oh My Posh with a theme. To use Oh My Posh with a theme of your choice (e.g., `atomic`), add the following idempotent initialization command to your `.bashrc` file:
     
     ```bash
     if ! grep -q 'oh-my-posh init bash --config ~/.cache/oh-my-posh/themes/atomic.omp.json' ~/.bashrc; then
@@ -98,13 +73,13 @@ Note: Except for AArch64/ARM64, Oh My Posh can be installed using Homebrew. Howe
     fi
     ```
     
-6. Reload the shell for the changes to take effect:
+5. Reload the shell for the changes to take effect:
     
     ```bash
     source ~/.bashrc
     ```
 
-7. Check the install using:
+6. Check the install using:
 
     ```bash
     oh-my-posh --version

--- a/prompt-customization/oh-my-posh-install-ubuntu.md
+++ b/prompt-customization/oh-my-posh-install-ubuntu.md
@@ -67,20 +67,35 @@ Note: Except for AArch64/ARM64, Oh My Posh can be installed using Homebrew. Howe
     
     close the `.profile` file (`Ctrl`+`O`, `Enter`, and then `Ctrl`+`X`)
 
-4. For user installed applications that live in `$HOME/.local/bin` to be available, `$HOME/.local/bin` should be in the `$PATH` environment variable. Therefore add a line in which `$HOME/.local/bin` is added to `$PATH` via an export, run: 
+4. For user installed applications that live in `$HOME/.local/bin` to be available, `$HOME/.local/bin` should be in the `$PATH` environment variable. Add this guarded block to `.profile` immediately before `# if running bash`:
 
 	```bash
-    echo -e "\n# Set $PATH so it includes user's private bin if it exists" >> ~/.bashrc && \
-        echo 'if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then' >> ~/.bashrc && \
-        echo '  export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc && \
-        echo "fi" >> ~/.bashrc
+    PROFILE="$HOME/.profile"
+    ANCHOR='^# if running bash$'
+    MARKER='HOME/.local/bin'
+
+    if ! grep -q "$MARKER" "$PROFILE"; then
+        if grep -q "$ANCHOR" "$PROFILE"; then
+            sed -i "/$ANCHOR/i\\
+    # Set PATH so it includes user's private bin if it exists\\
+    if [ -d \"$HOME/.local/bin\" ] && [[ \":$PATH:\" != *\":$HOME/.local/bin:\"* ]]; then\\
+      export PATH=\"$HOME/.local/bin:$PATH\"\\
+    fi\\
+    " "$PROFILE"
+        else
+            echo "WARNING: anchor line not found in $PROFILE - appending to end instead, check ordering manually" >&2
+            printf '\n# Set PATH so it includes user\'s private bin if it exists\nif [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then\n  export PATH="$HOME/.local/bin:$PATH"\nfi\n' >> "$PROFILE"
+        fi
+    fi
 	```
 
-5. Initialize Oh My Posh with a Theme. To use Oh My Posh with a theme of your choice (e.g., `atomic`), add the following initialization command to your `.bashrc` file for interactive, non-login shells:
+5. Initialize Oh My Posh with a theme. To use Oh My Posh with a theme of your choice (e.g., `atomic`), add the following idempotent initialization command to your `.bashrc` file:
     
     ```bash
-    echo -e "\n# Use Oh My Posh with atomic theme" >> ~/.bashrc && \
-    echo 'eval "$(oh-my-posh init bash --config ~/.cache/oh-my-posh/themes/atomic.omp.json)"' >> ~/.bashrc
+    if ! grep -q 'oh-my-posh init bash --config ~/.cache/oh-my-posh/themes/atomic.omp.json' ~/.bashrc; then
+        echo -e "\n# Use Oh My Posh with atomic theme" >> ~/.bashrc
+        echo 'eval "$(oh-my-posh init bash --config ~/.cache/oh-my-posh/themes/atomic.omp.json)"' >> ~/.bashrc
+    fi
     ```
     
 6. Reload the shell for the changes to take effect:

--- a/prompt-customization/oh-my-posh-install-windows.md
+++ b/prompt-customization/oh-my-posh-install-windows.md
@@ -6,7 +6,7 @@ These instructions assume you're using PowerShell on Windows 11. This guide cove
 
 ## Why Oh My Posh?
 
-To make interacting with the cross-platform PowerShell and Windows PowerShell using the terminal nicer and easier to digest, I like to pimp the prompt with [Oh My Posh](https://ohmyposh.dev/). This will also benefit working with Git. Of course you can find all instructions in the docs.
+To make working in the terminal - both cross-platform PowerShell and Windows PowerShell - nicer and easier to read, I like to pimp the prompt with [Oh My Posh](https://ohmyposh.dev/). This also improves the experience of working with Git. Full documentation is available at the link above.
 
 ## Installing Oh My Posh
 
@@ -22,39 +22,40 @@ To make interacting with the cross-platform PowerShell and Windows PowerShell us
     winget install -e --id JanDeDobbeleer.OhMyPosh --source winget
     ```
 
-2. After installing, restart the PowerShell terminal.
+2. After installing, you may have to restart the PowerShell terminal.
 
-3. Ensure that oh-my-posh is included in your user's PATH environment variable. Check this with:
-
-    ```powershell
-    'oh-my-posh is ' + (
-        ((Get-ChildItem Env:Path).Value -match 'oh-my-posh') ? 'found' : 'not found'
-        ) + ' in Path'
-    ```
-
-    If oh-my-posh is found, proceed to the next step. If it is not found, then check the location of the oh-my-posh binary first:
+3. Verify that oh-my-posh is resolvable from PowerShell:
 
     ```powershell
-    Get-Command oh-my-posh | Select-Object Source
+    Get-Command oh-my-posh -ErrorAction SilentlyContinue | Select-Object Source
     ```
 
-    and add it manually:
+    If this returns a `Source` path, Oh My Posh is correctly on your PATH - proceed to the next step.
+    In most cases this resolves to the WindowsApps App Execution Alias folder, e.g.
+    `$HOME\AppData\Local\Microsoft\WindowsApps\oh-my-posh.exe`, which is on PATH by default for every
+    user account, so no further action is needed.
+
+    If the command returns nothing, first restart the terminal (a fresh session picks up PATH changes
+    made by the installer). If it's still not found, locate the actual install directory - depending on
+    package version and install scope it may instead live machine-wide, e.g. under
+    `C:\Program Files (x86)\oh-my-posh\`. Check with:
 
     ```powershell
-    $env:Path += ";<path>"
+    Get-ChildItem "$env:LOCALAPPDATA\Programs\oh-my-posh" -Recurse -Filter oh-my-posh.exe -ErrorAction SilentlyContinue
+    Get-ChildItem "C:\Program Files (x86)\oh-my-posh" -Recurse -Filter oh-my-posh.exe -ErrorAction SilentlyContinue
     ```
 
-    Replace <path> with the actual directory where the Oh My Posh executable lives. On many systems this is in the user scope, e.g. `$HOME\AppData\Local\Microsoft\WindowsApps\`. If so then run:
+    Once you've found it, add it to your **user** PATH persistently (not just the current session):
 
     ```powershell
-    $env:Path += ";$HOME\AppData\Local\Microsoft\WindowsApps\"
+    [Environment]::SetEnvironmentVariable(
+        'Path',
+        [Environment]::GetEnvironmentVariable('Path', 'User') + ';<path-to-directory>',
+        'User'
+    )
     ```
 
-    Depending on package version/manifest and install scope, Oh My Posh may also be installed machine-wide (for example under `C:\Program Files (x86)\oh-my-posh\`). Always verify the actual location on your system with:
-
-    ```powershell
-    Get-Command oh-my-posh | Select-Object Source
-    ```
+    Replace `<path-to-directory>` with the actual folder containing `oh-my-posh.exe`. Then open a new terminal and re-run the `Get-Command` check.
 
     **Notes on Install Location and Theme Paths**
 
@@ -67,14 +68,13 @@ To make interacting with the cross-platform PowerShell and Windows PowerShell us
     oh-my-posh --version
     ```
 
-5. Oh My Posh requires a Nerd Font to render icons correctly. If you don’t already have one installed, you can use the built-in font installer instead of downloading and installing a Nerd font manually. In an elevated terminal, the font is installed globally, else the font is installed in the user's directory.
-   
+5. Oh My Posh requires a Nerd Font to render icons correctly. If you don't already have one installed, you can use the built-in font installer instead of downloading and installing a Nerd font manually. In an elevated terminal, the font is installed globally, else the font is installed in the user's directory.
+
     ```powershell
     oh-my-posh font install
     ```
 
     This opens an interactive menu. I recommend selecting [Hack Nerd Font](https://www.nerdfonts.com/font-downloads).
-
 
 ## Updating Oh My Posh
 

--- a/tools-ubuntu/uv-install-ubuntu.md
+++ b/tools-ubuntu/uv-install-ubuntu.md
@@ -30,7 +30,7 @@ Since `~/.local/bin` is already manually added to `$PATH`, which is where uv ins
 to also add `~/.local/bin` and create a duplicate entry. Therefore add following lines to `.bashrc` by running:
 
 ```bash
-echo "\n# Prevent uv from modifying shell profiles during updates" >> ~/.bashrc
+echo -e "\n# Prevent uv from modifying shell profiles during updates" >> ~/.bashrc
 echo "export UV_NO_MODIFY_PATH=1" >> ~/.bashrc
 ```
 

--- a/tools-ubuntu/uv-install-ubuntu.md
+++ b/tools-ubuntu/uv-install-ubuntu.md
@@ -27,11 +27,24 @@ uv
 You should see output similar to: An extremely fast Python package manager.
 
 Since `~/.local/bin` is already manually added to `$PATH`, which is where uv installs itself, we don't want uv 
-to also add `~/.local/bin` and create a duplicate entry. Therefore add following lines to `.bashrc` by running:
+to also add `~/.local/bin` and create a duplicate entry. Add the following export to `.profile` immediately before `# if running bash`:
 
 ```bash
-echo -e "\n# Prevent uv from modifying shell profiles during updates" >> ~/.bashrc
-echo "export UV_NO_MODIFY_PATH=1" >> ~/.bashrc
+PROFILE="$HOME/.profile"
+ANCHOR='^# if running bash$'
+MARKER='UV_NO_MODIFY_PATH'
+
+if ! grep -q "$MARKER" "$PROFILE"; then
+    if grep -q "$ANCHOR" "$PROFILE"; then
+        sed -i "/$ANCHOR/i\\
+# Prevent uv from modifying shell profiles during updates\\
+export UV_NO_MODIFY_PATH=1\\
+" "$PROFILE"
+    else
+        echo "WARNING: anchor line not found in $PROFILE - appending to end instead, check ordering manually" >&2
+        printf '\n# Prevent uv from modifying shell profiles during updates\nexport UV_NO_MODIFY_PATH=1\n' >> "$PROFILE"
+    fi
+fi
 ```
 
 
@@ -40,15 +53,19 @@ echo "export UV_NO_MODIFY_PATH=1" >> ~/.bashrc
 1. To enable shell autocompletion for uv commands, run the following:
 
     ```bash
-    echo -e "\n# Shell completion for uv" >> ~/.bashrc
-    echo 'eval "$(uv generate-shell-completion bash)"' >> ~/.bashrc
+    if ! grep -q 'uv generate-shell-completion bash' ~/.bashrc; then
+        echo -e "\n# Shell completion for uv" >> ~/.bashrc
+        echo 'eval "$(uv generate-shell-completion bash)"' >> ~/.bashrc
+    fi
     ```
 
 2. To enable shell autocompletion for uvx commands, execute:
 
     ```bash
-    echo -e "\n# Shell completion for uvx" >> ~/.bashrc
-    echo 'eval "$(uvx --generate-shell-completion bash)"' >> ~/.bashrc
+    if ! grep -q 'uvx --generate-shell-completion bash' ~/.bashrc; then
+        echo -e "\n# Shell completion for uvx" >> ~/.bashrc
+        echo 'eval "$(uvx --generate-shell-completion bash)"' >> ~/.bashrc
+    fi
     ```
 
     Note: uvx is a companion tool to uv that allows you to run Python scripts in ephemeral, isolated environments without needing to manually create virtual environments.

--- a/tools-windows/winget-check-install-windows.md
+++ b/tools-windows/winget-check-install-windows.md
@@ -4,7 +4,7 @@
 
 ## General Considerations
 
-[WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/) is a command line tool enabling users to discover, install, upgrade, remove and configure applications on Windows 10, Windows 11, and Windows Server 2025 computers. This tool is the client interface to the Windows Package Manager service.
+[WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/) is a command line tool enabling users to discover, install, upgrade, remove and configure applications on Windows 11 computers. This tool is the client interface to the Windows Package Manager service.
 
 ## Why WinGet
 

--- a/tools-windows/wsl-install-windows.md
+++ b/tools-windows/wsl-install-windows.md
@@ -39,23 +39,38 @@ Make sure that `Virtual Machine Platform` and `Windows Subsystem for Linux` feat
 - Installs the WSL kernel
 - Installs Ubuntu by default (you can choose another distro later)
 
-A restart during the WSL install will then be required, however. If you prefer this route proceed to [Installing WSL](#installing-wsl).
+A restart during the WSL install will then be required, however. If you prefer this route, proceed to [Installing WSL](#installing-wsl).
 
 Because I like to know what is happening under the hood and get a better understanding I prefer to:
 
 1. To check if the features are enabled run in an elevated terminal:
 
-    ```powershell
-    Get-WindowsOptionalFeature -Online |
-    Where-Object FeatureName -in @("VirtualMachinePlatform", "Microsoft-Windows-Subsystem-Linux")
-    ```
+   ```powershell
+   Get-WindowsOptionalFeature -Online |
+   Where-Object FeatureName -in @("VirtualMachinePlatform", "Microsoft-Windows-Subsystem-Linux")
+   ```
 
-    This will return the status of both features. Look for the State property in the output:
+   **Note**: this command can take a while (up to a minute or more) since it queries the full DISM feature database rather than just the two features you're filtering for. Don't assume it's frozen.
 
-    - Enabled means the feature is active.
-    - Disabled means it's not currently enabled.
+   If you want a faster check, `dism.exe` called directly skips some of PowerShell's overhead:
 
-    If not enabled, proceed to the next steps.
+   ```powershell
+   dism /online /get-featureinfo /featurename:VirtualMachinePlatform
+   dism /online /get-featureinfo /featurename:Microsoft-Windows-Subsystem-Linux
+   ```
+
+   Or, if you only care about WSL2 readiness rather than the feature state itself, `wsl --status` is near-instant and purpose-built for this:
+
+   ```powershell
+   wsl --status
+   ```
+
+   This will return the status of both features. Look for the State property in the output:
+
+   - Enabled means the feature is active.
+   - Disabled means it's not currently enabled.
+
+   If not enabled, proceed to the next steps.
 
 2. Enable the `Virtual Machine Platform` feature. In an elevated prompt run:
 
@@ -93,13 +108,28 @@ Now that WSL is installed, you can access it from within PowerShell to get all k
 wsl --version
 ```
 
-or the installed distributions with:
+The default distribution `Ubuntu` may or may not have been installed, just list the installed distributions with:
 
 ```powershell
 wsl --list --verbose
 ```
 
-You can also launch Ubuntu by running `wsl` in PowerShell, from the Start menu, or directly via Windows Terminal.
+If you get something like:
+
+```text
+Windows Subsystem for Linux has no installed distributions.
+```
+
+ypu can install one following the instruction or just simply install the default:
+
+```powershell
+wsl --install -d Ubuntu
+```
+
+You launch Ubuntu via several ways:
+   - running `wsl` in PowerShell
+   - from the Start menu
+   - directly via Windows Terminal.
 
 
 Hint: Frequently do:

--- a/windows-terminal/windows-terminal-check-install.md
+++ b/windows-terminal/windows-terminal-check-install.md
@@ -10,7 +10,7 @@ I use Windows Terminal in my dev setup on Windows with WSL Ubuntu because it all
 
 Windows Terminal is a terminal application for use with command-line tools and shells like Command Prompt, PowerShell, and WSL, i.e., Bash. It allows you to work with multiple tabs and supports Unicode and UTF-8 characters. Moreover, it can be customized via themes; styles can be set and configured.
 
-## Install Windows Terminal
+## Check that Windows Terminal is Installed
 
 Just like with WingGet, you should already have Windows Terminal since that comes with Windows 11. Check if you have Windows Terminal by running:
 
@@ -25,23 +25,5 @@ winget install -e --id Microsoft.WindowsTerminal
 ```
 
 Verify the installation by running Windows Terminal. 
-
-## Configure Windows Terminal
-
-Launch Windows Terminal (`WT`) and set it as default terminal:
-
-`WT`→`Settings`→`Startup`→`Default terminal application`→`Windows Terminal`
-
-Set the installed (Hack) Nerd font as default:
-
-`WT`→`Settings`→`Profiles`→`Defaults`→`Appearance`
-
-Set the `Color scheme`, `Font face`, and `Font size` here. I also set a background image here.
-
-Set the cross-platform PowerShell as the default profile:
-
-`WT`→`Settings`→`Startup`→`Default profile`→`PowerShell`
-
-Additionally, I love the GitHub Dark color scheme, therefore I've put the definition of it in a separate JSON file, <a href="color-scheme-windows-terminal.json">color-scheme-windows-terminal.json</a>, in this repo. You can copy it from there and paste it in your Windows Terminal JSON file at the appropriate location inside the schemes array (somewhere around line 100). You can open the Windows Terminal JSON file from within settings in the lower left corner.
 
 <a href="../README.md">Back to README</a>

--- a/windows-terminal/windows-terminal-config.md
+++ b/windows-terminal/windows-terminal-config.md
@@ -1,0 +1,25 @@
+<a href="../README.md">Back to README</a>
+
+# Configuring Windows Terminal
+
+Now that Oh My Posh, posh-git, and PowerShell are installed and configured, let's configure Windows Terminal. The configuration of Windows Terminal is can be done via the GUI or via a JSON file. Below are some directions to configure Windows Terminal via the GUI. If you prefer, you can also open the JSON file from within Windows Terminal settings in the lower left corner.
+
+## Configure Windows Terminal
+
+Launch Windows Terminal (`WT`) and set it as default terminal:
+
+`WT`→`Settings`→`Startup`→`Default terminal application`→`Windows Terminal`
+
+Set the installed (Hack) Nerd font as default:
+
+`WT`→`Settings`→`Profiles`→`Defaults`→`Appearance`
+
+Set the `Color scheme`, `Font face`, and `Font size` here. I also set a background image here.
+
+Set the cross-platform PowerShell as the default profile:
+
+`WT`→`Settings`→`Startup`→`Default profile`→`PowerShell`
+
+Additionally, I love the GitHub Dark color scheme, therefore I've put the definition of it in a separate JSON file, <a href="color-scheme-windows-terminal.json">color-scheme-windows-terminal.json</a>, in this repo. You can copy it from there and paste it in your Windows Terminal JSON file at the appropriate location inside the schemes array (somewhere around line 100). You can open the Windows Terminal JSON file from within settings in the lower left corner.
+
+<a href="../README.md">Back to README</a>


### PR DESCRIPTION
## Summary
This squash commit consolidates the documentation refresh for the Windows + WSL2 setup flow and adds stricter guidance for Bash startup ordering on Ubuntu in WSL2.

## Descirption

## What changed
- Split Windows Terminal documentation into separate check/install and configuration guides.
- Updated README navigation, ordering, and repo tree references to match the new guide structure.
- Added a dedicated WSL2 guide for .profile vs .bashrc:
    - profile-vs-bashrc-wsl2.md
- Clarified startup-order requirements for WSL2 Bash shells:
    - PATH/env exports must be set in .profile before .bashrc is sourced.
- Updated Ubuntu install docs for Oh My Posh and uv:
    - .profile export instructions now use anchor-based, idempotent insertion before # if running bash
    - .bashrc interactive additions (prompt/completions) remain append-based but are now idempotent
- Added canonical .profile example and Nano edit/save workflow in the new WSL2 guide.
- Updated changelog and bumped documented version to 3.1.0.

## Why
WSL2 commonly starts Bash as a login + interactive shell, so .profile and .bashrc execute in the same startup path. Incorrect ordering (or blind appends) can break tool initialization and cause PATH duplication/availability issues. These docs standardize a safe, repeatable approach.

## Impact
Improves reliability of Oh My Posh and uv/uvx initialization in WSL2.
Reduces risk of broken shell startup ordering and duplicate PATH entries.
Makes setup steps clearer and easier to verify across the repo